### PR TITLE
fix: set HOME and PATH env vars before uv installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,13 @@ RUN groupadd -g ${GROUP_ID} ${USERNAME} || true && \
 USER ${USERNAME}
 WORKDIR /home/${USERNAME}
 
+# Set HOME and PATH environment variables for proper tool installation
+ENV HOME=/home/${USERNAME}
+ENV PATH="$HOME/.local/bin:$PATH"
+
 # Install uv for Python package management
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+RUN mkdir -p "$HOME/.local/bin" && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && \
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 


### PR DESCRIPTION
Fixes #2

## Problem
The Docker build was failing with `/home/claude/.local/bin/uv: not found` because:
- HOME and PATH weren't set as Docker ENV variables
- The .local/bin directory might not exist before installation
- Subsequent RUN commands couldn't find the uv binary

## Solution
- Added `ENV HOME=/home/${USERNAME}`
- Added `ENV PATH="$HOME/.local/bin:$PATH"`
- Added `mkdir -p "$HOME/.local/bin"` before uv installation

This ensures uv tool install commands work correctly.

---
Generated with [Claude Code](https://claude.ai/code)