### PR TITLE
fix: resolve symlinks correctly when determining script directory

### DIFF
--- a/agentbox
+++ b/agentbox
@@ -5,36 +5,8 @@
 set -euo pipefail
 
 # Configuration
-# Cross-platform function to resolve symlinks (works on both Linux and macOS)
-resolve_symlink() {
-    local target="$1"
-    local max_iterations=40  # Prevent infinite loops on circular symlinks
-    local iteration=0
-
-    # Convert to absolute path if relative
-    if [[ "$target" != /* ]]; then
-        target="$(pwd)/$target"
-    fi
-
-    # Follow symlinks until we reach the actual file
-    while [[ -L "$target" ]] && [[ $iteration -lt $max_iterations ]]; do
-        local link_dir="$(dirname "$target")"
-        local link_target="$(readlink "$target")"
-
-        # If the symlink target is relative, make it absolute based on the link's directory
-        if [[ "$link_target" != /* ]]; then
-            target="$(cd "$link_dir" && cd "$(dirname "$link_target")" && pwd)/$(basename "$link_target")"
-        else
-            target="$link_target"
-        fi
-        iteration=$((iteration + 1))
-    done
-
-    echo "$target"
-}
-
-# Resolve symlinks to get the real script location
-readonly SCRIPT_PATH="$(resolve_symlink "${BASH_SOURCE[0]}")"
+# Resolve symlinks to get the real script location (allows installation as symlink)
+readonly SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 readonly PROJECT_DIR="$(pwd)"
 readonly PROJECT_NAME="$(basename "$PROJECT_DIR")"


### PR DESCRIPTION
Fixes #7

When agentbox is installed as a symlink (e.g., in `/usr/local/bin`), the script now correctly resolves the symlink to find the actual script location. This ensures `Dockerfile` and `entrypoint.sh` are found regardless of how the script is invoked.

## Changes
- Added `readlink -f` to resolve symlinks before determining script directory
- The script now works correctly whether executed directly or via symlink

----

Generated with [Claude Code](https://claude.ai/code)