### PR TITLE
feat: Add automatic MCP server configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
+
+# MCP configuration (may contain sensitive API keys)
+# Use .mcp.json.example as a template
+.mcp.json

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "memory-keeper": {
+      "command": "npx",
+      "args": ["mcp-memory-keeper"],
+      "env": {}
+    }
+  }
+}

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -54,6 +54,16 @@ Uses SHA256 hash of Dockerfile + entrypoint.sh stored as Docker image label. Com
 /home/claude/.claude    # Claude config (Docker volume)
 ```
 
+### MCP Server Configuration
+AgentBox supports automatic MCP server configuration from project-level `.mcp.json` files:
+- **Location**: `/workspace/.mcp.json` (project root)
+- **Detection**: Entrypoint script checks for `.mcp.json` on every container start
+- **Idempotency**: Only adds servers that aren't already configured
+- **Format**: Standard Claude Code MCP JSON format with `mcpServers` object
+- **Requirements**: Requires `jq` to be installed in the container (already included)
+- **Scope**: Uses `--scope local` which stores config in Docker volume
+- **Persistence**: MCP configs stored in Docker volume survive container deletion
+
 ## Testing Status
 - Basic functionality verified (help command, shell mode)
 - Full Docker build/run cycle needs real environment testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,10 @@ USER root
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Copy MCP functions
+COPY mcp_functions.sh /usr/local/bin/mcp_functions.sh
+RUN chmod +x /usr/local/bin/mcp_functions.sh
+
 # Set working directory
 WORKDIR /workspace
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,43 @@ This will:
 ### Environment Variables
 If a `.env` file exists in your project directory, the environment variables defined there will automatically be loaded into the container.
 
+## MCP Server Configuration
+
+AgentBox supports automatic MCP (Model Context Protocol) server configuration using a project-level `.mcp.json` file. This enables:
+- **Team collaboration**: Share MCP configurations via version control
+- **Project portability**: MCP servers configure automatically when teammates start the container
+- **Zero setup**: No need to manually run `claude mcp add` after container recreation
+
+### Setting Up Project-Level MCP Servers
+
+Create a `.mcp.json` file in your project root:
+
+```json
+{
+  "mcpServers": {
+    "memory-keeper": {
+      "command": "npx",
+      "args": ["mcp-memory-keeper"],
+      "env": {}
+    },
+    "custom-server": {
+      "command": "python",
+      "args": ["-m", "my_mcp_server"],
+      "env": {
+        "API_KEY": "your-key-here"
+      }
+    }
+  }
+}
+```
+
+When you start AgentBox, it will:
+1. Check if `.mcp.json` exists in your project
+2. Automatically configure any MCP servers not already set up
+3. Skip servers that are already configured (idempotent)
+
+**Note**: Environment variables in `.mcp.json` support expansion with `${VAR}` or `${VAR:-default}` syntax. You can reference variables from your project's `.env` file.
+
 ## Data Persistence
 
 ### Package Caches
@@ -120,6 +157,8 @@ Authentication data is stored in Docker named volumes (`agentbox-claude-<hash>`)
 - Per-project Claude CLI configuration
 - Persistent authentication across container restarts
 - Isolation between different projects
+
+**Note**: MCP servers configured via `claude mcp add` are stored in the Docker volume and persist across container restarts. However, using project-level `.mcp.json` is recommended for team collaboration.
 
 ## Volume Management
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,13 @@ if [ -z "$(git config --global user.email)" ]; then
     fi
 fi
 
+# Configure MCP servers from project-level .mcp.json if it exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/mcp_functions.sh" ]; then
+    source "${SCRIPT_DIR}/mcp_functions.sh"
+    configure_mcp_servers
+fi
+
 # Set terminal for better experience
 export TERM=xterm-256color
 

--- a/mcp_functions.sh
+++ b/mcp_functions.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# MCP server configuration functions
+# Provides automatic MCP server configuration from .mcp.json files
+
+get_server_name() {
+    echo "$1" | jq -r '.key'
+}
+
+get_server_command() {
+    echo "$1" | jq -r '.value.command'
+}
+
+get_server_args() {
+    echo "$1" | jq -r '.value.args[]?' | tr '\n' ' '
+}
+
+get_server_env_flags() {
+    echo "$1" | jq -r '.value.env | to_entries[] | "--env \(.key)=\(.value)"' | tr '\n' ' '
+}
+
+get_all_configured_servers() {
+    claude mcp list 2>&1 | grep -E "^[a-zA-Z0-9_-]+:" | cut -d: -f1
+}
+
+is_server_already_configured() {
+    local server_name="$1"
+    local configured_list="$2"
+    echo "$configured_list" | grep -q "^${server_name}$"
+}
+
+add_mcp_server() {
+    local server_json="$1"
+    local name=$(get_server_name "$server_json")
+    local cmd=$(get_server_command "$server_json")
+    local args=$(get_server_args "$server_json")
+    local env_flags=$(get_server_env_flags "$server_json")
+
+    echo "   + Adding $name..."
+    eval "claude mcp add --scope local $env_flags $name $cmd $args" 2>&1 | sed 's/^/     /'
+}
+
+check_jq_installed() {
+    if ! command -v jq &>/dev/null; then
+        echo "   ⚠ jq not found - skipping MCP auto-configuration"
+        return 1
+    fi
+}
+
+process_each_server_from_config() {
+    local configured_list="$1"
+    local config_file="${2:-/workspace/.mcp.json}"
+
+    jq -r '.mcpServers | to_entries[] | @json' "$config_file" 2>/dev/null | while read -r server; do
+        local name=$(get_server_name "$server")
+        if is_server_already_configured "$name" "$configured_list"; then
+            echo "   ✓ $name (already configured)"
+        else
+            add_mcp_server "$server"
+        fi
+    done
+}
+
+configure_mcp_servers() {
+    local config_file="${1:-/workspace/.mcp.json}"
+
+    [ ! -f "$config_file" ] && return 0
+
+    echo "🔧 Configuring MCP servers from $config_file..."
+    check_jq_installed || return 1
+
+    local configured=$(get_all_configured_servers)
+    process_each_server_from_config "$configured" "$config_file"
+    echo ""
+}


### PR DESCRIPTION
This PR adds automatic MCP server configuration from project-level `.mcp.json` files.

## What it does
- Enables teams to share MCP server configurations via version control
- Automatically configures MCP servers on container startup
- Makes the development environment more portable

## Changes
- Add `mcp_functions.sh` with configuration logic
- Integrate MCP setup into `entrypoint.sh`
- Document feature in README.md and DEVELOPMENT_NOTES.md
- Provide `.mcp.json.example` template
- Add `.mcp.json` to `.gitignore` for security

This eliminates manual setup when teammates start containers and reduces friction for new team members.