### PR TITLE
fix: Shell command with arguments now works properly

### DIFF
--- a/agentbox
+++ b/agentbox
@@ -251,7 +251,11 @@ run_container() {
         if [[ "$admin_mode" == "true" ]]; then
             container_cmd=(bash -c "echo '🔒 Admin shell - sudo access enabled' && exec ${cmd_args[*]:-/bin/zsh}")
         else
-            container_cmd=("${cmd_args[@]:-/bin/zsh}")
+            if [[ ${#cmd_args[@]} -gt 0 ]]; then
+                container_cmd=(/bin/zsh "${cmd_args[@]}")
+            else
+                container_cmd=(/bin/zsh)
+            fi
         fi
     else
         # Run claude through zsh to get proper environment


### PR DESCRIPTION
When calling 'agentbox shell -c "command"', the arguments are now correctly passed to zsh instead of being executed directly. This fixes the issue where shell arguments were not being interpreted by a shell, causing exec errors.

Examples that now work:
  agentbox shell -c "echo TEST_SUCCESS"
  agentbox shell -c "ls -la | grep README"
  agentbox shell -c "python3 --version"

Previously these would fail with "exec: <command>: not found" because arguments were passed directly to Docker exec instead of being interpreted by zsh.