### PR TITLE
Fix "unbound variable" errors

### DIFF
--- a/agentbox
+++ b/agentbox
@@ -281,15 +281,16 @@ run_container() {
     fi
 
     # Run ephemeral container with --rm
+    # ${array[@]+"${array[@]}"} avoids errors on macOS (bash 3) when array is empty.
     docker run -it --rm \
         --name "$container_name" \
         --hostname "agentbox-$PROJECT_NAME" \
-        "${mount_opts[@]}" \
-        "${env_file_args[@]}" \
+        ${mount_opts[@]+"${mount_opts[@]}"} \
+        ${env_file_args[@]+"${env_file_args[@]}"} \
         -w /workspace \
         --init \
         "$IMAGE_NAME" \
-        "${container_cmd[@]}"
+        ${container_cmd[@]+"${container_cmd[@]}"}
 }
 
 # Show help
@@ -470,12 +471,12 @@ main() {
     # Run or attach to container
     if [[ "$shell_mode" == "true" ]]; then
         if [[ "$admin_mode" == "true" ]]; then
-            run_container "$container_name" "shell" "--admin" "${cmd_args[@]}"
+            run_container "$container_name" "shell" "--admin" ${cmd_args[@]+"${cmd_args[@]}"}
         else
-            run_container "$container_name" "shell" "${cmd_args[@]}"
+            run_container "$container_name" "shell" ${cmd_args[@]+"${cmd_args[@]}"}
         fi
     else
-        run_container "$container_name" "${cmd_args[@]}"
+        run_container "$container_name" ${cmd_args[@]+"${cmd_args[@]}"}
     fi
 }
 


### PR DESCRIPTION
In bash 3.2.57 (system version on macOS 15), `"${array[@]}"` causes an "unbound variable" error when `array=()` and `nounset` is on (`set -u`).

The standard solution seems to be `${array[@]+"${array[@]}"}`.

This changes all instances of `"${array[@]}"` for future consistency, even though one of the variables should never be empty (`mount_opts`).

Fixes: #19

---

A possible alternative would be to wrap code that uses `"${array[@]}"` with `set +u` and `set -u`, but that seems easy to miss when updating the code, and it doesn’t catch `"${aray[@]}"`.