### PR TITLE
feat: Add multi-directory mounting support

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -44,7 +44,8 @@ After each successful rebuild, `docker image prune -f --filter "label=agentbox.v
 
 ### Mount Points
 ```bash
-/workspace              # Project directory (main mount)
+/workspace              # Project directory (main mount, always current directory)
+/<directory_name>       # Additional directories (via --add-dir flag, using folder basenames e.g., /foo, /bar)
 /home/claude/.ssh       # SSH keys from ~/.agentbox/ssh/
 /home/claude/.gitconfig # Git config (read-only)
 /home/claude/.npm       # NPM cache
@@ -102,7 +103,9 @@ The `agentbox` script has these key functions:
 - `calculate_hash()`: SHA256 hash for change detection
 - `needs_rebuild()`: Compare hashes with image label
 - `build_image()`: Docker build with proper args
-- `run_container()`: Main container execution logic
+- `mount_additional_dirs()`: Mount extra directories with intuitive folder names (e.g., /foo, /bar)
+- `validate_dir_path()`: Validate directory paths (traversal check, system dirs, existence, duplicates)
+- `run_container()`: Main container execution logic with all mounts and command execution
 - `ssh_setup()`: Initialize ~/.agentbox/ssh/ directory
 
 ## Critical Implementation Notes

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Docker-based development environment for running Claude CLI in a more safe, is
 ## Features
 
 - **Shares project directory with host**: Maps a volume with the source code so that you can see and modify the agent's changes on the host machine - just like if you were running Claude without a container.
+- **Multi-Directory Support**: Mount additional project directories for cross-project development
 - **Unified Development Environment**: Single Docker image with Python, Node.js, Java, and Shell support
 - **Automatic Rebuilds**: Detects changes to Dockerfile/entrypoint and rebuilds automatically
 - **Per-Project Isolation**: Each project directory gets its own isolated container environment
@@ -18,6 +19,27 @@ A Docker-based development environment for running Claude CLI in a more safe, is
 
 - **Docker**: Must be installed and running
 - **Bash 4.0+**: macOS ships with Bash 3.2, I recommend upgrading via Homebrew (`brew install bash`).
+
+## Multi-Directory Support
+
+AgentBox supports mounting additional directories for scenarios where your agent needs access to multiple projects:
+
+```bash
+# Mount a single additional directory
+agentbox --add-dir ~/other-project
+
+# Mount multiple directories (repeatable flag)
+agentbox --add-dir ~/proj1 --add-dir ~/proj2 --add-dir ~/proj3
+
+# Works with shell mode too
+agentbox --add-dir ~/library-code shell
+```
+
+**How it works:**
+- Your current directory is always mounted as `/workspace`
+- Additional directories are mounted using their folder names (e.g., `/foo`, `/bar`)
+- All directories are writable - changes sync back to the host
+- The mounting order follows the order you specify in the flag
 
 ## Installation
 
@@ -38,6 +60,9 @@ agentbox
 # Non-agentbox CLI flags are passed through to claude.
 # For example, to continue the most recent session
 agentbox -c
+
+# Mount additional directories for multi-project access
+agentbox --add-dir ~/proj1 --add-dir ~/proj2  # Multiple directories
 
 # Start shell with sudo privileges
 agentbox shell --admin
@@ -77,7 +102,7 @@ The unified Docker image includes:
 
 ## Authenticating to Git or other SCC Providers
 
-### GitHub 
+### GitHub
 The `gh` tool is included in the image and can be used for all GitHub operations. My recommendation:
 - Visit this link to configure a [fine-grained access-token](https://github.com/settings/personal-access-tokens/new?name=MyRepo-AI&description=For%20AI%20Agent%20Usage&contents=write&pull_requests=write&issues=write) with a sensible set of permissions predefined.
 - On that page, restrict the token to the project repository.

--- a/agentbox
+++ b/agentbox
@@ -124,10 +124,121 @@ build_image() {
     fi
 }
 
+expand_tilde() {
+    local path="$1"
+    if [[ "$path" =~ ^~ ]]; then
+        echo "${path/#\~/$HOME}"
+    else
+        echo "$path"
+    fi
+}
+
+has_path_traversal() {
+    local path="$1"
+    [[ "$path" =~ \.\. ]]
+}
+
+is_absolute_path() {
+    local path="$1"
+    [[ "$path" =~ ^/ ]]
+}
+
+is_critical_system_dir() {
+    local path="$1"
+    [[ "$path" =~ ^/(bin|sbin|boot|lib|lib64)(/|$) ]]
+}
+
+is_system_dir() {
+    local path="$1"
+    [[ "$path" =~ ^/(etc|var|usr|sys|proc|dev)(/|$) ]]
+}
+
+is_duplicate_dir() {
+    local path="$1"
+    local -n check_dirs_ref=$2
+
+    for existing_dir in "${check_dirs_ref[@]}"; do
+        if [[ "$path" == "$existing_dir" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+validate_dir_path() {
+    local dir="$1"
+    local -n validated_dirs_ref=$2
+    local project_realpath="$3"
+
+    dir=$(expand_tilde "$dir")
+
+    if has_path_traversal "$dir"; then
+        log_error "Path traversal not allowed: $dir"
+        return 1
+    fi
+
+    if ! is_absolute_path "$dir"; then
+        log_error "Directory must be absolute path: $dir"
+        return 1
+    fi
+
+    if [[ ! -d "$dir" ]]; then
+        log_error "Directory not found: $dir"
+        return 1
+    fi
+
+    local dir_realpath
+    dir_realpath=$(realpath "$dir" 2>/dev/null) || {
+        log_error "Cannot resolve path: $dir"
+        return 1
+    }
+
+    if is_critical_system_dir "$dir_realpath"; then
+        log_error "Mounting critical system directory not allowed: $dir_realpath"
+        return 1
+    fi
+
+    if [[ "$dir_realpath" == "$project_realpath" ]]; then
+        log_warning "Skipping duplicate: $dir (already mounted as /workspace)"
+        return 0  # Not an error, just skip
+    fi
+
+    if is_duplicate_dir "$dir_realpath" validated_dirs_ref; then
+        log_warning "Skipping duplicate directory: $dir"
+        return 0  # Not an error, just skip
+    fi
+
+    if is_system_dir "$dir_realpath"; then
+        log_warning "Mounting system directory: $dir_realpath (proceed with caution)"
+    fi
+
+    validated_dirs_ref+=("$dir_realpath")
+    return 0
+}
+
+# Mount additional dirs to Docker mount options
+mount_additional_dirs() {
+    local -n mount_opts_ref=$1
+    shift
+    local extra_dirs=("$@")
+
+    # Return early if no dirs to mount
+    if [[ ${#extra_dirs[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    for extra_dir in "${extra_dirs[@]}"; do
+        local dir_name=$(basename "$extra_dir")
+        mount_opts_ref+=(-v "$extra_dir:/${dir_name}:z")
+        log_info "Mounting additional directory: $extra_dir -> /${dir_name}"
+    done
+}
+
 # Run container with --rm (ephemeral)
 run_container() {
     local container_name="$1"
-    shift
+    local -n validated_dirs=$2
+    shift 2
 
     # Check if first arg is "shell" mode
     local shell_mode=false
@@ -154,6 +265,8 @@ run_container() {
     local mount_opts=(
         -v "$PROJECT_DIR:/workspace:z"
     )
+
+    mount_additional_dirs mount_opts "${validated_dirs[@]}"
 
     # Mount .gitconfig to temp location for copying (if it exists)
     if [[ -f "${HOME}/.gitconfig" ]]; then
@@ -298,6 +411,7 @@ Options:
     -p PORT                 Forward a port from host to container (can be used multiple times)
     --cleanup               Remove AgentBox image and cached data
     --rebuild               Force rebuild of the image
+    --add-dir DIR           Mount additional directory (can be used multiple times)
 
 Commands:
     shell [--admin]         Start interactive shell instead of Claude CLI
@@ -314,6 +428,7 @@ Examples:
     agentbox -p 3002:8080               # Map host port 3002 to container port 8080
     agentbox shell                      # Start interactive shell instead of Claude
     agentbox shell --admin              # Start admin shell with sudo access
+    agentbox --add-dir ~/1 --add-dir ~/2  # Add dirs with Claude CLI
     agentbox python script.py           # Run Python script in container
     agentbox --cleanup                  # Remove image and optionally cached data
     agentbox --rebuild                  # Force rebuild image
@@ -321,6 +436,9 @@ Examples:
 
 Containers are ephemeral and automatically removed when you exit.
 Package caches and shell history persist between sessions.
+
+Additional directories are mounted using their folder names (e.g., /foo, /bar).
+The current directory is always mounted as /workspace.
 EOF
 }
 
@@ -398,6 +516,7 @@ main() {
     local admin_mode=false
     local cmd_args=()
     declare -a ports=()
+    local extra_dirs=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -420,6 +539,15 @@ main() {
                     exit 1
                 fi
                 ports+=("$1")
+                shift
+                ;;
+            --add-dir)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    log_error "--add-dir requires a directory path"
+                    exit 1
+                fi
+                extra_dirs+=("$1")
                 shift
                 ;;
             shell)
@@ -457,6 +585,20 @@ main() {
     # Get container name for current project
     local container_name=$(get_container_name)
 
+    # Validate dir paths (batch all errors so user sees all problems at once)
+    local project_realpath
+    project_realpath=$(realpath "$PROJECT_DIR")
+    local validated_dirs=()
+    local validation_failed=false
+    for dir in "${extra_dirs[@]}"; do
+        if ! validate_dir_path "$dir" validated_dirs "$project_realpath"; then
+            validation_failed=true
+        fi
+    done
+
+    if [[ "$validation_failed" == "true" ]]; then
+        exit 1
+    fi
 
     # Check if rebuild is needed or forced
     if [[ "$force_rebuild" == "true" ]] || needs_rebuild; then
@@ -476,12 +618,12 @@ main() {
     # Run or attach to container
     if [[ "$shell_mode" == "true" ]]; then
         if [[ "$admin_mode" == "true" ]]; then
-            run_container "$container_name" "shell" "--admin" "${cmd_args[@]}"
+            run_container "$container_name" validated_dirs "shell" "--admin" "${cmd_args[@]}"
         else
-            run_container "$container_name" "shell" "${cmd_args[@]}"
+            run_container "$container_name" validated_dirs "shell" "${cmd_args[@]}"
         fi
     else
-        run_container "$container_name" "${cmd_args[@]}"
+        run_container "$container_name" validated_dirs "${cmd_args[@]}"
     fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,7 +91,7 @@ fi
 if [ -t 0 ] && [ -t 1 ]; then
     echo "🤖 AgentBox Development Environment"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "📁 Workspace: /workspace"
+    echo "📁 Project Directory: /workspace"
     echo "🐍 Python: $(python3 --version 2>&1 | cut -d' ' -f2) (uv available)"
     echo "🟢 Node.js: $(node --version 2>/dev/null || echo 'not found')"
     echo "☕ Java: $(java -version 2>&1 | head -1 | cut -d'"' -f2 || echo 'not found')"


### PR DESCRIPTION
Enable mounting multiple project directories for cross-project development workflows. Directories mount using their basenames (e.g., ~/code/foo → /foo) for intuitive path access within the container.

This addresses workflows where developers need access to shared libraries, related projects, or documentation repos alongside their main project, enabling seamless cross-project code references and reducing context switching.

Claude CLI's --add-dir flag accepts any paths without validation, including nonexistent paths, system directories, and path traversal attempts. AgentBox provides a security layer with comprehensive validation before passing directories to Docker.

Security validations:
- Block path traversal attempts (.. components)
- Reject critical system directories (/bin, /sbin, /boot, /lib, /lib64)
- Warn about risky system paths (/etc, /var, /usr, /sys, /proc, /dev)
- Verify directory existence for clear error messages
- Detect and skip duplicates to avoid mount confusion
- Expand tilde paths for user convenience
- Require absolute paths for clarity
- Batch validation errors so users see all problems at once

Features:
- Repeatable --add-dir flag (like docker -v or gcc -I)
- Mount directories as /basename for clean, predictable paths
- Support shell mode with proper argument handling


Examples:

```
agentbox --add-dir ~/proj1 --add-dir ~/proj2    # Mount multiple directories
agentbox --add-dir ~/library shell              # Mount with shell mode
```