### PR TITLE
Keep Claude up-to-date when rebuilding the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,10 +109,7 @@ RUN bash -c "source $NVM_DIR/nvm.sh && \
         prettier \
         nodemon \
         yarn \
-        pnpm \
-        @anthropic-ai/claude-code && \
-    # Verify Claude CLI installation
-    which claude && claude --version"
+        pnpm"
 
 # Install SDKMAN for Java toolchain management
 RUN curl -s "https://get.sdkman.io?rcupdate=false" | bash && \
@@ -204,6 +201,16 @@ WORKDIR /workspace
 
 # Set the user for runtime
 USER ${USERNAME}
+
+# Install Claude as last step
+# Changing the ARG (via --build-arg) will invalidate the cache for the
+# following steps and consequently install the latest Claude version
+ARG BUILD_TIMESTAMP=unknown
+RUN bash -c "source $NVM_DIR/nvm.sh && \
+    npm install -g \
+        @anthropic-ai/claude-code && \
+    # Verify Claude CLI installation
+    which claude && claude --version"
 
 # Entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/agentbox
+++ b/agentbox
@@ -106,13 +106,15 @@ build_image() {
     local group_id=$(id -g)
 
     # Build with progress output
+    local build_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     if docker build \
         --build-arg USER_ID="${user_id}" \
         --build-arg GROUP_ID="${group_id}" \
         --build-arg USERNAME="claude" \
+        --build-arg BUILD_TIMESTAMP=${build_timestamp} \
         --label "agentbox.hash=${combined_hash}" \
         --label "agentbox.version=1.0.0" \
-        --label "agentbox.built=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --label "agentbox.built=${build_timestamp}" \
         -t "$IMAGE_NAME" \
         "$SCRIPT_DIR" ; then
         log_success "Image built successfully!"


### PR DESCRIPTION
Claude Code gets updates almost every day, sometimes even twice a day. However, even when forcing a rebuild of the Docker image, Docker reads the `npm install` step from the cache and does _not_ update Claude Code. 

This change moves the installation of Claude Code to the end of the Dockerfile and forces an invalidation of the cache by including an (unused) `ARG`. This means, that every time you rebuild the Docker image, Claude Code is updated to the latest version.