### PR TITLE
fix: Resolve circular nameref warning

### DIFF
--- a/agentbox
+++ b/agentbox
@@ -239,7 +239,7 @@ mount_additional_dirs() {
 # Run container with --rm (ephemeral)
 run_container() {
     local container_name="$1"
-    local -n validated_dirs=$2
+    local -n extra_dirs_to_mount=$2
     shift 2
 
     # Check if first arg is "shell" mode
@@ -268,7 +268,7 @@ run_container() {
         -v "$PROJECT_DIR:/workspace:z"
     )
 
-    mount_additional_dirs mount_opts "${validated_dirs[@]}"
+    mount_additional_dirs mount_opts "${extra_dirs_to_mount[@]}"
 
     # Mount .gitconfig to temp location for copying (if it exists)
     if [[ -f "${HOME}/.gitconfig" ]]; then


### PR DESCRIPTION
Bash nameref variables must have different names than the variable they reference. The nameref was named 'validated_dirs', same as the variable passed from main(), causing bash to warn about circular reference (validated_dirs pointing to itself).

Renamed to 'extra_dirs_to_mount' to avoid the collision.