### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # AgentBox
 
+[![Run in Smithery](https://smithery.ai/badge/skills/fletchgqc)](https://smithery.ai/skills?ns=fletchgqc&utm_source=github&utm_medium=badge)
+
+
 A Docker-based development environment for running Claude CLI in a more safe, isolated fashion. This makes it less dangerous to use YOLO mode (`--dangerously-skip-permissions`), which is, in my opinion, the only way to use AI agents.
 
 ## Features


### PR DESCRIPTION
## Add skill discoverability badge

Your 2 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/fletchgqc)](https://smithery.ai/skills?ns=fletchgqc&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.