### PR TITLE
fix: dereference symlinks when initializing Claude config volume

### DIFF
--- a/agentbox
+++ b/agentbox
@@ -325,13 +325,18 @@ run_container() {
                 -v "${claude_volume_name}:/dest" \
                 --user root \
                 "$IMAGE_NAME" \
-                sh -c "cp -r /source/* /dest/ 2>/dev/null; chown -R ${uid}:${gid} /dest"
+                sh -c "
+                    cd /source &&
+                    find . -maxdepth 1 ! -name '.' -exec cp -rL -- '{}' /dest/ \; 2>/dev/null
+                    mkdir -p /dest/plugins/marketplaces 2>/dev/null || true
+                    chown -R ${uid}:${gid} /dest
+                "
         else
             docker run --rm \
                 -v "${claude_volume_name}:/dest" \
                 --user root \
                 "$IMAGE_NAME" \
-                chown -R ${uid}:${gid} /dest
+                sh -c "mkdir -p /dest/plugins/marketplaces; chown -R ${uid}:${gid} /dest"
         fi
     fi
 


### PR DESCRIPTION
Fixes #44

When copying the host's ~/.claude config to the container volume, symlinks
were being copied as references rather than their targets. Since those paths
don't exist inside the container, directories like plugins/ became inaccessible.

This change:
- Uses `cp -rL` to dereference symlinks during volume initialization
- Ensures `plugins/marketplaces` directory exists for Claude Code marketplace/plugin management

Generated by [Claude Code](https://claude.ai/code) - GLM 4.7