### PR TITLE
feat(ux): add config file support and standardize configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ Thumbs.db
 
 # User config (keep config.example as template)
 /config
+
+# AgentBox project directories
+projects/
+
+# Local agent documentation
+.agents/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 .env
 .env.local
 .env.*.local
+
+# User config (keep config.example as template)
+/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 # AgentBox - Simplified multi-language development environment for Claude
 FROM debian:trixie
 
+# Optional Java toolchain (default: on for compatibility)
+ARG INCLUDE_JAVA=true
+
+# Claude Code channel (stable or latest)
+ARG CC_CHANNEL=stable
+
+# Include OpenCode (default: on)
+ARG INCLUDE_OPENCODE=true
+
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=en_US.UTF-8
@@ -33,8 +42,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         # Python build dependencies
         python3-dev python3-pip python3-venv \
         libssl-dev libffi-dev \
-        # Java dependencies
-        default-jdk maven gradle \
+        # Java dependencies (conditional)
+        $(if [ "$INCLUDE_JAVA" = "true" ]; then echo "default-jdk maven gradle"; fi) \
         # Search tools
         ripgrep fd-find && \
     # Setup locale
@@ -123,13 +132,15 @@ RUN bash -c "source $NVM_DIR/nvm.sh && \
         yarn \
         pnpm"
 
-# Install SDKMAN for Java toolchain management
-RUN curl -s "https://get.sdkman.io?rcupdate=false" | bash && \
-    echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.bashrc && \
-    echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.zshrc && \
-    bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
-        sdk install java 21.0.9-tem && \
-        sdk install gradle"
+# Install SDKMAN for Java toolchain management (conditional)
+RUN if [ "$INCLUDE_JAVA" = "true" ]; then \
+        curl -s "https://get.sdkman.io?rcupdate=false" | bash && \
+        echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.bashrc && \
+        echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.zshrc && \
+        bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+            sdk install java 21.0.9-tem && \
+            sdk install gradle"; \
+    fi
 
 # Setup Python tools
 RUN /home/${USERNAME}/.local/bin/uv tool install black && \
@@ -213,11 +224,13 @@ USER ${USERNAME}
 # Dockerfile hasn't changed. This ensures fresh installs on explicit rebuilds instead
 # of relying on unpredictable auto-update timing.
 ARG BUILD_TIMESTAMP=unknown
-RUN curl -fsSL https://claude.ai/install.sh | bash -s stable && \
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CC_CHANNEL} && \
     zsh -i -c 'which claude && claude --version'
 
-RUN curl -fsSL https://opencode.ai/install | bash && \
-    zsh -i -c 'which opencode && opencode --version'
+RUN if [ "$INCLUDE_OPENCODE" = "true" ]; then \
+        curl -fsSL https://opencode.ai/install | bash && \
+        zsh -i -c 'which opencode && opencode --version'; \
+    fi
 
 # Entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@
 FROM debian:trixie
 
 # Optional Java toolchain (default: on for compatibility)
-ARG INCLUDE_JAVA=true
+ARG AGENTBOX_INCLUDE_JAVA=true
 
 # Claude Code channel (stable or latest)
-ARG CC_CHANNEL=stable
+ARG AGENTBOX_CC_CHANNEL=stable
 
 # Include OpenCode (default: on)
-ARG INCLUDE_OPENCODE=true
+ARG AGENTBOX_INCLUDE_OPENCODE=true
+
+# Simple traditional Unix-style prompt (default: off for backwards compatibility)
+ARG AGENTBOX_SIMPLE_PROMPT=false
 
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -43,7 +46,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python3-dev python3-pip python3-venv \
         libssl-dev libffi-dev \
         # Java dependencies (conditional)
-        $(if [ "$INCLUDE_JAVA" = "true" ]; then echo "default-jdk maven gradle"; fi) \
+        $(if [ "$AGENTBOX_INCLUDE_JAVA" = "true" ]; then echo "default-jdk maven gradle"; fi) \
         # Search tools
         ripgrep fd-find && \
     # Setup locale
@@ -133,7 +136,7 @@ RUN bash -c "source $NVM_DIR/nvm.sh && \
         pnpm"
 
 # Install SDKMAN for Java toolchain management (conditional)
-RUN if [ "$INCLUDE_JAVA" = "true" ]; then \
+RUN if [ "$AGENTBOX_INCLUDE_JAVA" = "true" ]; then \
         curl -s "https://get.sdkman.io?rcupdate=false" | bash && \
         echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.bashrc && \
         echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.zshrc && \
@@ -176,6 +179,11 @@ if [[ -n "$PS1" ]] && command -v stty >/dev/null; then
   _update_size
 fi
 EOF
+
+# Simple traditional Unix-style prompt (opt-in: AGENTBOX_SIMPLE_PROMPT=true)
+RUN if [ "$AGENTBOX_SIMPLE_PROMPT" = "true" ]; then \
+    echo 'PROMPT='"'"'%n@%m:%~ $ '"'"'' >> ~/.zshrc; \
+    fi
 
 # Configure git
 RUN git config --global init.defaultBranch main && \
@@ -224,10 +232,10 @@ USER ${USERNAME}
 # Dockerfile hasn't changed. This ensures fresh installs on explicit rebuilds instead
 # of relying on unpredictable auto-update timing.
 ARG BUILD_TIMESTAMP=unknown
-RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CC_CHANNEL} && \
+RUN curl -fsSL https://claude.ai/install.sh | bash -s ${AGENTBOX_CC_CHANNEL} && \
     zsh -i -c 'which claude && claude --version'
 
-RUN if [ "$INCLUDE_OPENCODE" = "true" ]; then \
+RUN if [ "$AGENTBOX_INCLUDE_OPENCODE" = "true" ]; then \
         curl -fsSL https://opencode.ai/install | bash && \
         zsh -i -c 'which opencode && opencode --version'; \
     fi

--- a/agentbox
+++ b/agentbox
@@ -129,6 +129,9 @@ build_image() {
         --build-arg GROUP_ID="${group_id}" \
         --build-arg USERNAME="agent" \
         --build-arg BUILD_TIMESTAMP=${build_timestamp} \
+        --build-arg INCLUDE_JAVA="${include_java}" \
+        --build-arg INCLUDE_OPENCODE="${include_opencode}" \
+        --build-arg CC_CHANNEL="${cc_channel}" \
         --label "agentbox.hash=${combined_hash}" \
         --label "agentbox.version=1.0.0" \
         --label "agentbox.built=${build_timestamp}" \
@@ -498,6 +501,9 @@ Options:
     --add-dir DIR               Mount additional directory (can be used multiple times)
     --ignore-dot-env            Do not load .env files as environment variables (still mounted)
     --dangerously-mount-docker  Mount Docker socket (requires Docker Desktop)
+    --no-java                   Exclude Java toolchain for smaller image (default: included)
+    --no-opencode               Exclude OpenCode installation for smaller image (default: included)
+    --cc-latest                 Use Claude Code latest channel instead of stable (may be ahead of stable)
 
 Commands:
     shell [--admin]             Start interactive shell instead of Claude CLI
@@ -507,6 +513,11 @@ Commands:
     Use 'shell' command to get a shell instead of Claude CLI.
     Use 'shell --admin' to get a shell with sudo privileges.
     Other commands will be executed inside the container.
+
+Configuration:
+    Config file: ~/.agentbox/config
+    CLI flags override config file settings.
+    See config.example for all available options.
 
 Examples:
     agentbox                              # Start Claude CLI for current project
@@ -570,8 +581,20 @@ ssh_setup() {
     log_info "AgentBox will use this directory for all SSH operations."
 }
 
+# Load config file if exists
+load_config() {
+    local config_file="${HOME}/.agentbox/config"
+    if [[ -f "$config_file" ]]; then
+        # Source the config file, allowing it to override defaults
+        source "$config_file"
+    fi
+}
+
 # Main execution
 main() {
+    # Load config file first (before CLI args, so CLI args can override)
+    load_config
+
     # Parse arguments
     local force_rebuild=false
     local shell_mode=false
@@ -581,7 +604,10 @@ main() {
     declare -a ports=()
     local extra_dirs=()
     local tool="${AGENTBOX_TOOL:-claude}"
-    local ignore_dot_env=false
+    local ignore_dot_env="${AGENTBOX_IGNORE_DOT_ENV:-false}"
+    local include_java="${AGENTBOX_INCLUDE_JAVA:-true}"
+    local include_opencode="${AGENTBOX_INCLUDE_OPENCODE:-true}"
+    local cc_channel="${AGENTBOX_CC_CHANNEL:-stable}"
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -626,6 +652,18 @@ main() {
                 ;;
             --ignore-dot-env)
                 ignore_dot_env=true
+                shift
+                ;;
+            --no-java)
+                include_java=false
+                shift
+                ;;
+            --no-opencode)
+                include_opencode=false
+                shift
+                ;;
+            --cc-latest)
+                cc_channel=latest
                 shift
                 ;;
             shell)

--- a/agentbox
+++ b/agentbox
@@ -695,6 +695,11 @@ main() {
         exit 1
     fi
 
+    # Auto-enable OpenCode if tool is set to opencode
+    if [[ "$tool" == "opencode" ]]; then
+        include_opencode=true
+    fi
+
     # Check runtime
     RUNTIME=$(check_runtime)
     log_info "Using container runtime: $RUNTIME"

--- a/agentbox
+++ b/agentbox
@@ -129,9 +129,10 @@ build_image() {
         --build-arg GROUP_ID="${group_id}" \
         --build-arg USERNAME="agent" \
         --build-arg BUILD_TIMESTAMP=${build_timestamp} \
-        --build-arg INCLUDE_JAVA="${include_java}" \
-        --build-arg INCLUDE_OPENCODE="${include_opencode}" \
-        --build-arg CC_CHANNEL="${cc_channel}" \
+        --build-arg AGENTBOX_INCLUDE_JAVA="${include_java}" \
+        --build-arg AGENTBOX_INCLUDE_OPENCODE="${include_opencode}" \
+        --build-arg AGENTBOX_CC_CHANNEL="${cc_channel}" \
+        --build-arg AGENTBOX_SIMPLE_PROMPT="${simple_prompt}" \
         --label "agentbox.hash=${combined_hash}" \
         --label "agentbox.version=1.0.0" \
         --label "agentbox.built=${build_timestamp}" \
@@ -608,6 +609,7 @@ main() {
     local include_java="${AGENTBOX_INCLUDE_JAVA:-true}"
     local include_opencode="${AGENTBOX_INCLUDE_OPENCODE:-true}"
     local cc_channel="${AGENTBOX_CC_CHANNEL:-stable}"
+    local simple_prompt="${AGENTBOX_SIMPLE_PROMPT:-false}"
 
     while [[ $# -gt 0 ]]; do
         case "$1" in

--- a/config.example
+++ b/config.example
@@ -14,5 +14,8 @@
 # Claude Code channel: stable or latest - default: stable
 # AGENTBOX_CC_CHANNEL=latest
 
+# Simple traditional Unix-style prompt (user@host:~) - default: false
+# AGENTBOX_SIMPLE_PROMPT=true
+
 # Ignore .env files - default: false
 # AGENTBOX_IGNORE_DOT_ENV=true

--- a/config.example
+++ b/config.example
@@ -1,0 +1,18 @@
+#!/bin/bash
+# AgentBox configuration
+# Copy this file to ~/.agentbox/config to customize defaults
+
+# Tool selection: claude (default) or opencode
+# AGENTBOX_TOOL=claude
+
+# Include Java toolchain (JDK, Maven, Gradle) - default: true
+# AGENTBOX_INCLUDE_JAVA=false
+
+# Include OpenCode - default: true
+# AGENTBOX_INCLUDE_OPENCODE=false
+
+# Claude Code channel: stable or latest - default: stable
+# AGENTBOX_CC_CHANNEL=latest
+
+# Ignore .env files - default: false
+# AGENTBOX_IGNORE_DOT_ENV=true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ if [ -t 0 ] && [ -t 1 ]; then
     echo "📁 Project Directory: ${PROJECT_DIR:-unknown}"
     echo "🐍 Python: $(python3 --version 2>&1 | cut -d' ' -f2) (uv available)"
     echo "🟢 Node.js: $(node --version 2>/dev/null || echo 'not found')"
-    echo "☕ Java: $(java -version 2>&1 | head -1 | cut -d'"' -f2 || echo 'not found')"
+    echo "☕ Java: $(command -v java >/dev/null 2>&1 && java -version 2>&1 | head -1 | cut -d'"' -f2 || echo 'excluded (--no-java)')"
     if [ "$TOOL" = "opencode" ]; then
         echo "🤖 OpenCode: $(opencode --version 2>/dev/null || echo 'not found - check installation')"
     else


### PR DESCRIPTION
## Summary

- Add `~/.agentbox/config` file for persistent settings (bash key=value format)
- Add `--no-java` flag to exclude Java toolchain (default: included for backwards compatibility)
- Add `--no-opencode` flag to exclude OpenCode installation (default: included)
- Add `--cc-latest` flag for Claude Code latest channel (default: stable)
- Fix Java status message to show friendly "excluded" text instead of command-not-found error
- Auto-enable OpenCode when `AGENTBOX_TOOL=opencode` is set, overriding `AGENTBOX_INCLUDE_OPENCODE=false`
- Standardize all Docker ARG names with AGENTBOX_ prefix for consistency
- Add AGENTBOX_SIMPLE_PROMPT for optional traditional Unix-style prompt (user@host:~)
- Add projects/ and .agents/ directories to .gitignore

## Configuration

Config file supports bash syntax with shebang for editor syntax highlighting:

```
#!/bin/bash
# ~/.agentbox/config

AGENTBOX_TOOL=claude
AGENTBOX_INCLUDE_JAVA=false
AGENTBOX_INCLUDE_OPENCODE=false
AGENTBOX_CC_CHANNEL=latest
AGENTBOX_SIMPLE_PROMPT=true
```

CLI flags override config file settings.

## Examples

```
# Use config file defaults
~/.agentbox/agentbox --model glm-4.7

# Override config with CLI flags
~/.agentbox/agentbox --no-java --cc-latest --model glm-4.7

# Config file with all options
cp config.example ~/.agentbox/config
```

## Benefits

- Users can set preferred defaults without typing flags every time
- Backwards compatible: Java and OpenCode still included by default
- Smaller images possible with `--no-java` and `--no-opencode`
- Latest Claude Code accessible via `--cc-latest` flag
- Tool selection (opencode) automatically includes required installation
- Consistent AGENTBOX_ prefix across all configuration options
- Optional simple prompt for users preferring traditional Unix style
- projects/ and .agents/ gitignored to avoid accidental commits of local project directories and agent notes
