### PR TITLE
fix: resolve Claude Code plugin loading in containers

### DIFF
--- a/agentbox
+++ b/agentbox
@@ -367,6 +367,7 @@ run_container() {
         mount_opts+=(
             -v "${claude_dir}:/home/agent/.claude"
             --env "CLAUDE_CONFIG_DIR=/home/agent/.claude"
+            --env "HOST_HOME=${HOME}"
         )
 
         log_info "Claude CLI configuration mounted"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,19 @@ set -e
 
 export PATH="$HOME/.opencode/bin:$HOME/.local/bin:$PATH"
 
+if [ -n "${HOST_HOME:-}" ] && [ "$HOST_HOME" != "$HOME" ]; then
+    host_home_parent=$(dirname "$HOST_HOME")
+
+    if [ ! -d "$host_home_parent" ]; then
+        sudo mkdir -p "$host_home_parent" 2>/dev/null || true
+    fi
+
+    if [ -d "$host_home_parent" ] && [ ! -e "$HOST_HOME" ]; then
+        sudo ln -s "$HOME" "$HOST_HOME" 2>/dev/null && \
+            echo "✅ Symlinked $HOST_HOME -> $HOME for plugin path resolution"
+    fi
+fi
+
 if [ -s "$HOME/.nvm/nvm.sh" ]; then
     export NVM_DIR="$HOME/.nvm"
     source "$NVM_DIR/nvm.sh"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,17 +4,10 @@ set -e
 
 export PATH="$HOME/.opencode/bin:$HOME/.local/bin:$PATH"
 
-if [ -n "${HOST_HOME:-}" ] && [ "$HOST_HOME" != "$HOME" ]; then
-    host_home_parent=$(dirname "$HOST_HOME")
-
-    if [ ! -d "$host_home_parent" ]; then
-        sudo mkdir -p "$host_home_parent" 2>/dev/null || true
-    fi
-
-    if [ -d "$host_home_parent" ] && [ ! -e "$HOST_HOME" ]; then
-        sudo ln -s "$HOME" "$HOST_HOME" 2>/dev/null && \
-            echo "✅ Symlinked $HOST_HOME -> $HOME for plugin path resolution"
-    fi
+if [ -n "${HOST_HOME:-}" ] && [ "$HOST_HOME" != "$HOME" ] && [ ! -e "$HOST_HOME/.claude" ]; then
+    sudo mkdir -p "$HOST_HOME" 2>/dev/null || true
+    sudo ln -s "$HOME/.claude" "$HOST_HOME/.claude" 2>/dev/null && \
+        echo "✅ Symlinked $HOST_HOME/.claude -> $HOME/.claude for plugin path resolution"
 fi
 
 if [ -s "$HOME/.nvm/nvm.sh" ]; then


### PR DESCRIPTION
## Problem

Claude Code plugins fail to load inside AgentBox containers. Plugin JSON files (`known_marketplaces.json`, `installed_plugins.json`) store absolute paths from the host (e.g., `~/.claude/plugins/...`), but inside the container `~/.claude` is mounted at `/home/agent/.claude`. The host paths do not resolve.

Ref: #48

## Solution

1. Pass `HOST_HOME` env var to the container with the host's home directory path
2. In the entrypoint, create a symlink: `$HOST_HOME/.claude -> /home/agent/.claude`

This allows Claude CLI to resolve the absolute paths stored in plugin config files without modifying any files on the host.

### Details

- `HOST_HOME` is only set for the Claude tool path (not OpenCode)
- The symlink is idempotent and ephemeral (created in container filesystem, destroyed on exit)
- `sudo` is used for the symlink since the entrypoint runs as non-root; passwordless sudo is already configured in the Dockerfile
- `mkdir -p` handles the case where Docker may or may not have already created the parent directory

## Testing

Verified on macOS host:
- Plugins visible in `/skills` and `/plugin` TUI
- Enable/disable state persists across container restarts
- Agents visible via `/agents`


🤖 Generated by [Amp Code](https://ampcode.com)  