### PR TITLE
feat: mount ~/.agents directory automatically

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -84,6 +84,7 @@ $PROJECT_DIR            # Project directory (mounted at full host path)
 /home/agent/.m2         # Maven cache
 /home/agent/.gradle     # Gradle cache
 /home/agent/.shell_history  # History directory (HISTFILE env var points to zsh_history inside)
+/home/agent/.agents     # Centralized agents directory (skills, prompts, etc.)
 /home/agent/.claude     # Claude config
 /home/agent/.config/opencode  # OpenCode config
 /home/agent/.local/share/opencode  # OpenCode auth

--- a/agentbox
+++ b/agentbox
@@ -372,6 +372,13 @@ run_container() {
         log_info "Claude CLI configuration mounted"
     fi
 
+    # Mount centralized agents directory (skills, prompts, etc.)
+    local agents_dir="${HOME}/.agents"
+    if [[ -d "$agents_dir" ]]; then
+        mount_opts+=(-v "${agents_dir}:/home/agent/.agents")
+        log_info "Agents directory mounted"
+    fi
+
     # Set tool environment variable
     mount_opts+=(--env "TOOL=$tool")
 


### PR DESCRIPTION
## Summary
- Mount `~/.agents` directory at `/home/agent/.agents` inside container
- Only mounts if `~/.agents` exists on host (graceful, no error if missing)
- Supports centralized agents directory for skills, prompts, etc.

## Test plan
- [x] Run `./agentbox shell` and verify `ls -la ~/.agents` shows host contents
- [x] Verify no error when `~/.agents` doesn't exist on host

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5