### PR TITLE
Allow customizing in-container shell prompt via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,16 @@ if [[ -n "$PS1" ]] && command -v stty >/dev/null; then
 fi
 EOF
 
+# Allow custom shell prompt:
+#   AGENTBOX_PROMPT_PREFIX prepends to the default prompt (preserves theme decorations)
+#   AGENTBOX_PROMPT / AGENTBOX_BASH_PROMPT replace it entirely (full override wins over prefix)
+RUN printf '%s\n' \
+        '[ -n "$AGENTBOX_PROMPT_PREFIX" ] && PROMPT="$AGENTBOX_PROMPT_PREFIX$PROMPT"' \
+        '[ -n "$AGENTBOX_PROMPT" ] && PROMPT="$AGENTBOX_PROMPT"' >> ~/.zshrc && \
+    printf '%s\n' \
+        '[ -n "$AGENTBOX_PROMPT_PREFIX" ] && PS1="$AGENTBOX_PROMPT_PREFIX$PS1"' \
+        '[ -n "${AGENTBOX_BASH_PROMPT:-$AGENTBOX_PROMPT}" ] && PS1="${AGENTBOX_BASH_PROMPT:-$AGENTBOX_PROMPT}"' >> ~/.bashrc
+
 # Configure git
 RUN git config --global init.defaultBranch main && \
     git config --global pull.rebase false

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Environment variables are loaded from `.env` files in this order (later override
 AGENTBOX_EXTRA_HOSTS="gitlab.example.com:host-gateway"
 ```
 
+`AGENTBOX_PROMPT_PREFIX` prepends to the default prompt in both shells, preserving the existing theme decorations (e.g. oh-my-zsh `git:(branch)`):
+
+```bash
+AGENTBOX_PROMPT_PREFIX="[box] "
+```
+
+For full control, `AGENTBOX_PROMPT` replaces the entire zsh `PROMPT`, and `AGENTBOX_BASH_PROMPT` replaces bash `PS1` (useful when you want shell-native color syntax in each: zsh `%F{red}` vs. bash `\[\e[31m\]`). A full override wins over the prefix when both are set; if only `AGENTBOX_PROMPT` is set, bash uses it too.
+
 AgentBox includes `direnv` support - `.envrc` files are evaluated if `direnv allow`ed on the host.
 
 ## MCP Server Configuration


### PR DESCRIPTION
Adds three opt-in env vars (set in ~/.agentbox/.env) to customize the in-container shell prompt:
  - AGENTBOX_PROMPT_PREFIX — prepends to the default prompt in both shells, preserving theme decorations (e.g. oh-my-zsh git:(branch))
  - AGENTBOX_PROMPT — replaces zsh PROMPT entirely
  - AGENTBOX_BASH_PROMPT — replaces bash PS1 entirely

  A full override wins over the prefix when both are set. Default behavior unchanged when none are set.

  Motivation: visual cue to distinguish the in-container shell from the host shell, without requiring users to rebuild their theme by
  hand.