### PR TITLE
feat: Add -e flag to pass environment variables to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ This will:
 3. Generate a new Ed25519 key pair (if preferred, delete them and manually place your desired SSH keys in `~/.agentbox/ssh/`).
 
 ### Environment Variables
-Environment variables are loaded from `.env` files in this order (later overrides earlier):
+Environment variables are passed to the container from these sources, in order (later overrides earlier):
 1. `~/.agentbox/.env` (global)
 2. `<project-dir>/.env` (project-specific)
+3. `-e KEY=VALUE` flags (command line)
 
 `AGENTBOX_EXTRA_HOSTS` (in `~/.agentbox/.env`) injects entries into the container's `/etc/hosts` via Docker's `--add-host`. Useful when the container needs to reach host-tunneled services:
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Environment variables are passed to the container from these sources, in order (
 2. `<project-dir>/.env` (project-specific)
 3. `-e KEY=VALUE` flags (command line)
 
+`-e KEY` (without `=`) passes through `KEY` from the host environment. Use `-e KEY=VALUE` to inject secrets from a manager, e.g. `agentbox -e GH_TOKEN=$(op read 'op://vault/item/token')`.
+
 `AGENTBOX_EXTRA_HOSTS` (in `~/.agentbox/.env`) injects entries into the container's `/etc/hosts` via Docker's `--add-host`. Useful when the container needs to reach host-tunneled services:
 
 ```bash

--- a/agentbox
+++ b/agentbox
@@ -259,7 +259,8 @@ run_container() {
     local tool="$3"
     local ignore_dot_env="$4"
     local mount_docker_socket="$5"
-    shift 5
+    local -n pass_env_vars=$6
+    shift 6
 
     # Check if first arg is "shell" mode
     local shell_mode=false
@@ -427,6 +428,14 @@ run_container() {
         log_info ".env files not loaded (--ignore-dot-env flag set)"
     fi
 
+    # Pass through -e environment variables (after env files, so they take precedence)
+    local pass_env_args=()
+    for env_var in "${pass_env_vars[@]}"; do
+        pass_env_args+=(--env "$env_var")
+        local env_name="${env_var%%=*}"
+        log_info "Environment variable: $env_name"
+    done
+
     # Build extra host entries from AGENTBOX_EXTRA_HOSTS
     local host_args=()
     local extra_hosts=""
@@ -476,6 +485,7 @@ run_container() {
         "${port_args[@]}" \
         "${mount_opts[@]}" \
         "${env_file_args[@]}" \
+        "${pass_env_args[@]}" \
         -w "$PROJECT_DIR" \
         --init \
         "$IMAGE_NAME" \
@@ -493,6 +503,7 @@ Usage:
 Options:
     -h, --help                  Show this help message
     --tool TOOL                 Choose tool: claude (default) or opencode
+    -e KEY=VALUE                Pass environment variable to container (can be used multiple times)
     -p PORT                     Forward a port from host to container (can be used multiple times)
     --rebuild                   Force rebuild of the image
     --add-dir DIR               Mount additional directory (can be used multiple times)
@@ -517,6 +528,7 @@ Examples:
     agentbox shell --admin                # Start admin shell with sudo access
     agentbox --add-dir ~/1 --add-dir ~/2  # Add dirs with Claude CLI
     agentbox python script.py             # Run Python script in container
+    agentbox -e GH_TOKEN=\$(op read '...')  # Pass env var (e.g. from 1Password)
     agentbox --rebuild                    # Force rebuild image
     agentbox ssh-init                     # Set up SSH for AgentBox
     AGENTBOX_TOOL=opencode agentbox       # Use env var to select tool
@@ -580,6 +592,7 @@ main() {
     local cmd_args=()
     declare -a ports=()
     local extra_dirs=()
+    local env_vars=()
     local tool="${AGENTBOX_TOOL:-claude}"
     local ignore_dot_env=false
 
@@ -604,6 +617,15 @@ main() {
                     exit 1
                 fi
                 ports+=("$1")
+                shift
+                ;;
+            -e)
+                shift
+                if [[ -z "${1:-}" ]]; then
+                    log_error "-e requires a value (KEY=VALUE or KEY)"
+                    exit 1
+                fi
+                env_vars+=("$1")
                 shift
                 ;;
             --add-dir)
@@ -697,12 +719,12 @@ main() {
     # Run or attach to container
     if [[ "$shell_mode" == "true" ]]; then
         if [[ "$admin_mode" == "true" ]]; then
-            run_container "$container_name" validated_dirs "$tool" "$ignore_dot_env" "$docker_mount" "shell" "--admin" "${cmd_args[@]}"
+            run_container "$container_name" validated_dirs "$tool" "$ignore_dot_env" "$docker_mount" env_vars "shell" "--admin" "${cmd_args[@]}"
         else
-            run_container "$container_name" validated_dirs "$tool" "$ignore_dot_env" "$docker_mount" "shell" "${cmd_args[@]}"
+            run_container "$container_name" validated_dirs "$tool" "$ignore_dot_env" "$docker_mount" env_vars "shell" "${cmd_args[@]}"
         fi
     else
-        run_container "$container_name" validated_dirs "$tool" "$ignore_dot_env" "$docker_mount" "${cmd_args[@]}"
+        run_container "$container_name" validated_dirs "$tool" "$ignore_dot_env" "$docker_mount" env_vars "${cmd_args[@]}"
     fi
 }
 

--- a/agentbox
+++ b/agentbox
@@ -503,7 +503,8 @@ Usage:
 Options:
     -h, --help                  Show this help message
     --tool TOOL                 Choose tool: claude (default) or opencode
-    -e KEY=VALUE                Pass environment variable to container (can be used multiple times)
+    -e KEY[=VALUE]              Pass environment variable to container (can be used multiple times)
+                                KEY alone forwards it from the host
     -p PORT                     Forward a port from host to container (can be used multiple times)
     --rebuild                   Force rebuild of the image
     --add-dir DIR               Mount additional directory (can be used multiple times)
@@ -528,7 +529,7 @@ Examples:
     agentbox shell --admin                # Start admin shell with sudo access
     agentbox --add-dir ~/1 --add-dir ~/2  # Add dirs with Claude CLI
     agentbox python script.py             # Run Python script in container
-    agentbox -e GH_TOKEN=\$(op read '...')  # Pass env var (e.g. from 1Password)
+    agentbox -e GH_TOKEN                  # Forward GH_TOKEN from host environment
     agentbox --rebuild                    # Force rebuild image
     agentbox ssh-init                     # Set up SSH for AgentBox
     AGENTBOX_TOOL=opencode agentbox       # Use env var to select tool


### PR DESCRIPTION
Mirrors Docker's -e KEY=VALUE syntax. Flags are applied after .env files so they take precedence. Closes #68, #49 