### PR TITLE
Use sdkman and nvm to install other versions of sdks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,14 +141,49 @@ RUN /home/${USERNAME}/.local/bin/uv tool install black && \
     /home/${USERNAME}/.local/bin/uv tool install pipenv
 
 # Install oh-my-zsh for better shell experience and setup NVM for zsh
+# oh-my-zsh installer replaces .zshrc, so all tool hooks are re-added after
 RUN sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended && \
     sed -i 's/ZSH_THEME=".*"/ZSH_THEME="robbyrussell"/' ~/.zshrc && \
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && \
     echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.zshrc && \
     echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.zshrc && \
-    echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> ~/.zshrc
+    echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"' >> ~/.zshrc && \
+    echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> ~/.zshrc
 
-# Setup direnv hooks for automatic .envrc loading
+# NVM auto-use hook + SDKMAN auto-env hook with auto-install.
+# SDKMAN's built-in sdkman_auto_env=true only calls 'sdk env' (no install), which
+# prints "Stop! X is not installed" on stdout when the version is missing.
+# We implement our own chpwd hooks that call 'sdk env install' first.
+RUN cat >> ~/.zshrc <<'EOF'
+
+# Auto-use NVM version from .nvmrc on cd and shell startup
+autoload -U add-zsh-hook
+load-nvmrc() {
+    local nvmrc_path
+    nvmrc_path="$(nvm_find_nvmrc)"
+    if [[ -n "$nvmrc_path" ]]; then
+        local nvmrc_node_version
+        nvmrc_node_version=$(nvm version "$(cat "$nvmrc_path")")
+        if [[ "$nvmrc_node_version" = "N/A" ]]; then
+            nvm install
+        elif [[ "$nvmrc_node_version" != "$(nvm version)" ]]; then
+            nvm use --silent
+        fi
+    fi
+}
+add-zsh-hook chpwd load-nvmrc
+load-nvmrc
+
+# SDKMAN: install missing versions then activate, on cd and shell startup
+__sdk_auto_env() {
+    if [[ -f ".sdkmanrc" ]]; then
+        sdk env install 2>/dev/null || true
+        sdk env 2>/dev/null || true
+    fi
+}
+add-zsh-hook chpwd __sdk_auto_env
+__sdk_auto_env
+EOF
 RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc && \
     echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
 

--- a/agentbox
+++ b/agentbox
@@ -334,6 +334,16 @@ run_container() {
         -v "${cache_dir}/gradle:/home/agent/.gradle"
     )
 
+    # SDK version caches are shared across projects (versions are large, project-agnostic)
+    local nvm_versions_dir="${HOME}/.agentbox/nvm/versions"
+    local sdkman_candidates_dir="${HOME}/.agentbox/sdkman/candidates"
+    mkdir -p "$nvm_versions_dir" "$sdkman_candidates_dir"
+
+    mount_opts+=(
+        -v "${nvm_versions_dir}:/home/agent/.nvm/versions"
+        -v "${sdkman_candidates_dir}:/home/agent/.sdkman/candidates"
+    )
+
     # Mount per-project persistent data
     local project_data_dir="${HOME}/.agentbox/projects/${container_name}"
     local history_dir="${project_data_dir}/history"

--- a/agentbox
+++ b/agentbox
@@ -533,9 +533,11 @@ Examples:
     agentbox ssh-init                     # Set up SSH for AgentBox
     AGENTBOX_TOOL=opencode agentbox       # Use env var to select tool
 
-Environment variables (set in ~/.agentbox/.env):
-    AGENTBOX_EXTRA_HOSTS    Comma-separated host:ip pairs added to container /etc/hosts
-                            Example: gitlab.example.com:host-gateway
+Environment variables:
+    ~/.agentbox/.env        Loaded into every container (global secrets, API keys, etc.)
+    $PROJECT_DIR/.env       Loaded into the container for that project only
+    AGENTBOX_EXTRA_HOSTS    Special variable in ~/.agentbox/.env: comma-separated host:ip
+                            pairs added to /etc/hosts. Example: gitlab.example.com:host-gateway
 
 Containers are ephemeral and automatically removed when you exit.
 Package caches and shell history persist between sessions.

--- a/agentbox
+++ b/agentbox
@@ -345,7 +345,7 @@ run_container() {
         --env "HISTFILE=/home/agent/.shell_history/zsh_history"
     )
 
-    if [[ "$tool" == "opencode" ]]; then
+    if [[ "$tool" == "opencode" || "$shell_mode" == "true" ]]; then
         local opencode_config_dir="${HOME}/.config/opencode"
         local opencode_auth_dir="${HOME}/.local/share/opencode"
 
@@ -358,7 +358,9 @@ run_container() {
         )
 
         log_info "OpenCode configuration and auth mounted"
-    else
+    fi
+
+    if [[ "$tool" == "claude" || "$shell_mode" == "true" ]]; then
         local claude_dir="${HOME}/.claude"
 
         mkdir -p "$claude_dir"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,27 @@ if [ -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
     source "$HOME/.sdkman/bin/sdkman-init.sh"
 fi
 
+if [ -n "$PROJECT_DIR" ] && [ -f "$PROJECT_DIR/.nvmrc" ]; then
+    echo "🟢 Installing Node.js from .nvmrc..."
+    cd "$PROJECT_DIR"
+    nvm install 2>&1 || true
+    nvm use 2>&1 || true
+elif ! node --version > /dev/null 2>&1; then
+    echo "🟢 No Node.js found, installing LTS..."
+    nvm install --lts 2>&1 || true
+    nvm alias default node 2>/dev/null || true
+    nvm use default 2>/dev/null || true
+fi
+
+if [ -n "$PROJECT_DIR" ] && [ -f "$PROJECT_DIR/.sdkmanrc" ]; then
+    echo "☕ Installing SDK versions from .sdkmanrc..."
+    cd "$PROJECT_DIR"
+    sdk env install 2>&1 || true
+elif ! java -version > /dev/null 2>&1; then
+    echo "☕ No Java found, installing default (21.0.9-tem)..."
+    sdk install java 21.0.9-tem < /dev/null 2>&1 || true
+fi
+
 if [ -n "$PROJECT_DIR" ] && [ ! -d "$PROJECT_DIR/.venv" ] && [ -f "$PROJECT_DIR/requirements.txt" -o -f "$PROJECT_DIR/pyproject.toml" -o -f "$PROJECT_DIR/setup.py" ]; then
     echo "🐍 Python project detected, creating virtual environment..."
     cd "$PROJECT_DIR"


### PR DESCRIPTION
The SDKMAN and NVM that are installed in the Dockerfile now automatically load the required versions and activates them when there is a .sdkmanrc or .nvmrc.
Also: In "shell" Mode, the opencode filesystem bindings are added so that it is possible to run opencode from shell mode.