### PR TITLE
feat: add Pi coding agent support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,6 +219,11 @@ RUN curl -fsSL https://claude.ai/install.sh | bash -s stable && \
 RUN curl -fsSL https://opencode.ai/install | bash && \
     zsh -i -c 'which opencode && opencode --version'
 
+RUN export NVM_DIR="/home/${USERNAME}/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+    npm install -g @earendil-works/pi-coding-agent && \
+    zsh -i -c 'which pi && pi --version'
+
 # Entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/bin/zsh"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ agentbox --help
 
 - claude code: built-in
 - opencode: built-in
+- pi: built-in (opt-in via `--tool pi`)
 - any other agents (copilot CLI, Aider, Cursor CLI...): easily add it yourself using the prompt at [docs/prompts/add-tool.md](docs/prompts/add-tool.md).
 
 ### Adding tools
@@ -88,6 +89,9 @@ agentbox
 
 # Use OpenCode instead of Claude
 agentbox --tool opencode
+
+# Use Pi instead of Claude (requires ANTHROPIC_API_KEY in .env)
+agentbox --tool pi
 
 # Or set via environment variable
 AGENTBOX_TOOL=opencode agentbox
@@ -133,6 +137,7 @@ Persistent data (survives container removal):
   History: ~/.agentbox/projects/agentbox-<hash>/history/
   Claude: ~/.claude
   OpenCode: ~/.config/opencode and ~/.local/share/opencode
+  Pi: ~/.pi
 ```
 
 ## Languages and Tools
@@ -145,6 +150,7 @@ The unified container image includes:
 - **Shell**: Zsh (default) and Bash with common utilities
 - **Claude CLI**: Pre-installed with per-project authentication
 - **OpenCode**: Pre-installed as an alternative AI coding tool
+- **Pi**: Pre-installed (opt-in via `--tool pi`)
 
 ## Authenticating to Git or other SCC Providers
 
@@ -230,6 +236,9 @@ Both tools use bind mounts to share authentication across all AgentBox projects:
 **OpenCode**:
 - Config: `~/.config/opencode` mounted at `/home/agent/.config/opencode`
 - Auth: `~/.local/share/opencode` mounted at `/home/agent/.local/share/opencode`
+
+**Pi**:
+- `~/.pi` mounted at `/home/agent/.pi`
 
 ## Advanced Usage
 

--- a/agentbox
+++ b/agentbox
@@ -359,6 +359,16 @@ run_container() {
         )
 
         log_info "OpenCode configuration and auth mounted"
+    elif [[ "$tool" == "pi" ]]; then
+        local pi_dir="${HOME}/.pi"
+
+        mkdir -p "$pi_dir"
+
+        mount_opts+=(
+            -v "${pi_dir}:/home/agent/.pi"
+        )
+
+        log_info "Pi configuration mounted"
     else
         local claude_dir="${HOME}/.claude"
 
@@ -397,6 +407,8 @@ run_container() {
         local tool_cmd
         if [[ "$tool" == "opencode" ]]; then
             tool_cmd="opencode"
+        elif [[ "$tool" == "pi" ]]; then
+            tool_cmd="pi"
         else
             tool_cmd="claude --dangerously-skip-permissions"
         fi
@@ -502,7 +514,7 @@ Usage:
 
 Options:
     -h, --help                  Show this help message
-    --tool TOOL                 Choose tool: claude (default) or opencode
+    --tool TOOL                 Choose tool: claude (default), opencode, or pi
     -e KEY[=VALUE]              Pass environment variable to container (can be used multiple times)
                                 KEY alone forwards it from the host
     -p PORT                     Forward a port from host to container (can be used multiple times)
@@ -641,7 +653,7 @@ main() {
             --tool)
                 shift
                 if [[ -z "${1:-}" ]]; then
-                    log_error "--tool requires a value (claude or opencode)"
+                    log_error "--tool requires a value (claude, opencode, or pi)"
                     exit 1
                 fi
                 tool="$1"
@@ -675,8 +687,8 @@ main() {
     done
 
     # Validate tool selection
-    if [[ "$tool" != "claude" && "$tool" != "opencode" ]]; then
-        log_error "Invalid tool: $tool (must be 'claude' or 'opencode')"
+    if [[ "$tool" != "claude" && "$tool" != "opencode" && "$tool" != "pi" ]]; then
+        log_error "Invalid tool: $tool (must be 'claude', 'opencode', or 'pi')"
         exit 1
     fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,6 +69,8 @@ if [ -t 0 ] && [ -t 1 ]; then
     echo "☕ Java: $(java -version 2>&1 | head -1 | cut -d'"' -f2 || echo 'not found')"
     if [ "$TOOL" = "opencode" ]; then
         echo "🤖 OpenCode: $(opencode --version 2>/dev/null || echo 'not found - check installation')"
+    elif [ "$TOOL" = "pi" ]; then
+        echo "🤖 Pi: $(pi --version 2>/dev/null || echo 'not found - check installation')"
     else
         echo "🤖 Claude CLI: $(claude --version 2>/dev/null || echo 'not found - check installation')"
     fi


### PR DESCRIPTION
## Summary

- Add Pi coding agent (pi.dev) as a built-in tool, installed unconditionally alongside Claude and OpenCode
- Add `--tool pi` CLI flag for running Pi instead of Claude
- Mount `~/.pi` directory for Pi configuration persistence
- Add Pi status line in container startup output

Pi is selected via `--tool pi` or `AGENTBOX_TOOL=pi` environment variable. Requires `ANTHROPIC_API_KEY` in `.env` for authentication.

## Test plan

- [x] Verify `agentbox --tool pi` starts Pi agent
- [x] Confirm Pi appears in `--help` output and tool validation
- [x] Verify `~/.pi` is mounted and persists between sessions

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 5