### PR TITLE
Honor host CLAUDE_CONFIG_DIR as Claude mount source

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Both tools use bind mounts to share authentication across all AgentBox projects:
 
 **Claude CLI**:
 - `~/.claude` mounted at `/home/agent/.claude`
+- Set `CLAUDE_CONFIG_DIR` on the host to mount a different directory (e.g. separate work/personal accounts), matching native Claude Code.
 
 **OpenCode**:
 - Config: `~/.config/opencode` mounted at `/home/agent/.config/opencode`

--- a/agentbox
+++ b/agentbox
@@ -360,7 +360,7 @@ run_container() {
 
         log_info "OpenCode configuration and auth mounted"
     else
-        local claude_dir="${HOME}/.claude"
+        local claude_dir="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
 
         mkdir -p "$claude_dir"
 
@@ -369,7 +369,7 @@ run_container() {
             --env "CLAUDE_CONFIG_DIR=/home/agent/.claude"
         )
 
-        log_info "Claude CLI configuration mounted"
+        log_info "Claude CLI configuration mounted from ${claude_dir}"
     fi
 
     # Set tool environment variable


### PR DESCRIPTION
Mounts ${CLAUDE_CONFIG_DIR:-${HOME}/.claude} instead of a hardcoded ~/.claude, matching native Claude Code's [undocumented] convention for selecting a config directory.

This lets separate host directories back separate accounts (e.g. work vs personal) by pointing CLAUDE_CONFIG_DIR at a different folder per shell alias:

```
agentbox-work() { CLAUDE_CONFIG_DIR=~/.claude-work agentbox "$@"; }
```

Works on both Linux and OSX, doesn't affect default behavior.  This is helpful for _my_ usecase of sharing a work and personal device, and I presume that's a somewhat common setup, but you won't hurt my feelings if you don't think this should go into the main agentbox.